### PR TITLE
Fix refresh_repos error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,10 +38,12 @@ def refresh_repos():
         try:
             logging.info("Refreshing repositories...")
             output = subprocess.check_output(["zypper", "refresh"])
-        except CalledProcessError:
+            err = None
+            break
+        except subprocess.CalledProcessError as e:
+            err = e
             time.sleep(300)
             continue
-        break
     else:
         logging.warning("An error occured while refreshing repos. See output below.")
         print(err.output)


### PR DESCRIPTION
The CalledProcessError was missing the subprocess module and err was not correctly set to get the output in case of error.